### PR TITLE
chore(deploy): Ignore main and master branches in deployment

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -2,8 +2,6 @@ name: Unit Test
 
 on:
   push:
-    branches:
-      - '**'
     branches-ignore:
       - main
       - master


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration in `.github/workflows/deploy-test.yml` to refine the conditions under which the workflow is triggered.

Workflow trigger refinement:

* [`.github/workflows/deploy-test.yml`](diffhunk://#diff-3506104a54b3d6803b340621fae99e8ea135690eab9799c489eb239f54587ed7R7-R9): Added `branches-ignore` to exclude the `main` and `master` branches from triggering the workflow on `push` events.